### PR TITLE
reduce frequency of leader election for components in the management …

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2320,6 +2320,9 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 							"--alsologtostderr",
 							"--v=4",
 							"--leader-elect=true",
+							"--leader-elect-lease-duration=60s",
+							"--leader-elect-retry-period=15s",
+							"--leader-elect-renew-deadline=40s",
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
@@ -2566,6 +2569,9 @@ func reconcileAutoScalerDeployment(deployment *appsv1.Deployment, hc *hyperv1.Ho
 		// we might end up locked with three nodes.
 		"--skip-nodes-with-local-storage=false",
 		"--alsologtostderr",
+		"--leader-elect-lease-duration=60s",
+		"--leader-elect-retry-period=15s",
+		"--leader-elect-renew-deadline=40s",
 		"--v=4",
 	}
 


### PR DESCRIPTION
…cluster

This reduces the leader election frequencies of components that leader elect in the management cluster to the centralized API Server of that cluster. At scale: all these components end up aggregating requests to the API Server and if not reduced appropriately it can cause substantial load on both the etcd database and apiserver memory/cpu usage. The default values previously triggered election updates every 2 seconds. This pr moves those to be 15 seconds which should provide significant alleviation of the pressure the apiserver is experiencing at max scale (440 clusters in a management cluster).

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.